### PR TITLE
Add Keytopia — free touch typing with 3D lessons, analytics & classrooms

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -89,6 +89,16 @@ Contains: **Lessons | Statistics | Dark Mode | Font Size | 3 Layouts | Full Scre
 
 ---
 
+**[Keytopia](https://keytopia.org/) [ FREE ]**
+Free touch-typing platform with a full curriculum, adaptive practice, and school tools. Lessons include 3D finger-placement visualization; an adaptive engine targets weak keys. Advanced analytics cover keyboard heatmaps, bigram timing, finger-efficiency radar, consistency and rhythm scores, speed distribution, and full test replay. Compete in 2D and 3D multiplayer car races, tournaments, challenges, and leaderboards; earn badges, levels, and verifiable Bronze–Diamond certifications. Educators get classrooms, assignments, live progress, and certificates.
+
+Languages available: many (including multi-layout practice). Keyboard Settings: Show keyboard | Layout options | Themes.
+
+Contains: **Lessons | 3D Finger Placement | Adaptive Practice | Speed Test | Games | 2D/3D Races | Tournaments | Statistics (Heatmaps, Bigrams, Finger Efficiency) | Classrooms | Certifications | Badges | Friends | Challenges | Themes**.
+
+---
+
+
 
 **[Typey Type](https://didoesdigital.com/typey-type/) [ FREE ][ STENOGRAPHY ]**
 Typey Type for Stenographers is a free typing app designed to help steno students practise and master stenography.


### PR DESCRIPTION
## What

Adds [Keytopia](https://keytopia.org) under **Learning → Online**.

## Why it fits

Keytopia is a full touch-typing *tutor* (curriculum + adaptive practice + classrooms + certifications), not only a speed test.

### Highlights
- **3D finger-placement visualization** in lessons
- **Adaptive practice engine** that targets weak keys
- **Advanced analytics:** keyboard heatmaps, bigram timing, finger-efficiency radar, consistency & rhythm scores, speed distribution, full test replay
- **2D and 3D multiplayer car races**, tournaments, friends, challenges, badges
- **Educator classrooms** with assignments, live progress, and grading
- **Verifiable certifications** Bronze (40 WPM) → Diamond (200 WPM)

Free, web / PWA, no account required to start practicing.

Website: https://keytopia.org